### PR TITLE
Handle version and requirements in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include VERSION
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("VERSION", "r") as fh:
-    version = fh.read()
+    version = fh.read().strip()
 
 with open("requirements.txt", "r") as fh:
-    requirements = fh.readlines()
+    requirements = fh.read().splitlines()
 
 setup(
     name='eu2020',


### PR DESCRIPTION
Ahoj,
hrál jsem si teď trochu s tím toxem a narazil jsem při tom na dvě drobnosti, které by se měly opravit, i kdybychom tox v projektu nepoužívali.

1. při generování tzv. _source distribution_ příkazem `python setup.py sdist` nejsou do výsledného archivu zahrnuty soubory `VERSION` a `requirements.txt`, což má za následek, že takovou distribuci nelze korektně nainstalovat příkazem `pip install`.

Toto jsem vyřešil přidáním `MANIFEST.in`.

2. během hrátek s toxem jsem narazil na warning, že informace o verzi obsahuje na konci newline, což by nemělo být.

Toto jsem vyřešil pomocí `strip` a rovnou jsem to pořešil i u hodnoty `requirements`

před:
`version='0.4.0\n', requirements=['rich\n']`

po:
`version='0.4.0', requirements=['rich']`
