### PR TITLE
Remove rest of option keys

### DIFF
--- a/eu2020/common/utils.py
+++ b/eu2020/common/utils.py
@@ -33,7 +33,7 @@ def clear() -> None:
 
 def auto_set_option_keys(event) -> None:
     keys_used = []
-    for option in event.get("options", []):
+    for option in reversed(event.get("options", [])):
         if "key" not in option:
             for k in option["description"]:
                 if k != ' ' and k not in keys_used:

--- a/eu2020/common/utils.py
+++ b/eu2020/common/utils.py
@@ -33,6 +33,11 @@ def clear() -> None:
 
 def auto_set_option_keys(event) -> None:
     keys_used = []
+
+    for option in event.get("options", []):
+        if "key" in option:
+            keys_used.append(option["key"])
+
     for option in reversed(event.get("options", [])):
         if "key" not in option:
             for k in option["description"]:

--- a/eu2020/common/utils.py
+++ b/eu2020/common/utils.py
@@ -32,6 +32,11 @@ def clear() -> None:
 
 
 def auto_set_option_keys(event) -> None:
+    keys_used = []
     for option in event.get("options", []):
         if "key" not in option:
-            option["key"] = option["description"][0]
+            for k in option["description"]:
+                if k != ' ' and k not in keys_used:
+                    option["key"] = k
+                    keys_used.append(k)
+                    break

--- a/eu2020/data/ev_admin_eb.py
+++ b/eu2020/data/ev_admin_eb.py
@@ -44,7 +44,6 @@ ev_admin_eb = [
         },
         "options": [
             {
-                "key": "t",
                 "description": "podpořit kvantitativní uvolňování tiskem nových peněz",
                 "delay": 12,
                 "impact": {
@@ -52,7 +51,6 @@ ev_admin_eb = [
                 }
             },
             {
-                "key": "s",
                 "description": "podpořit kvantitativní uvolňování zavedením záporných úrokových sazeb",
                 "delay": 12,
                 "impact": {

--- a/eu2020/data/ev_admin_ek.py
+++ b/eu2020/data/ev_admin_ek.py
@@ -40,7 +40,6 @@ ev_admin_ek = [
         },
         "options": [
             {
-                "key": "s",
                 "description": "odsouhlasit podání žaloby na Polsko, Česko, Slovensko a Maďarsko",
                 "delay": -1,
                 "impact": {
@@ -71,7 +70,6 @@ ev_admin_ek = [
                        "už není křesťanská a vánoční oslavy nejsou dostatečně inkluzivní.",
         "options": [
             {
-                "key": "s",
                 "description": "odsouhlasit dokument",
                 "delay": -1,
                 "impact": {

--- a/eu2020/data/ev_admin_esd.py
+++ b/eu2020/data/ev_admin_esd.py
@@ -19,7 +19,6 @@ ev_admin_esd = [
                 }
             },
             {
-                "key": "e",
                 "description": "nepodpořit Lichtenštejnsko u Evropského soudu",
                 "delay": -1,
                 "impact": {
@@ -55,7 +54,6 @@ ev_admin_esd = [
                 }
             },
             {
-                "key": "o",
                 "description": "nepodpořit pokutu",
                 "delay": -1,
                 "impact": {

--- a/eu2020/data/ev_deep_state_nez.py
+++ b/eu2020/data/ev_deep_state_nez.py
@@ -34,7 +34,6 @@ ev_deep_state_nez = [
         },
         "options": [
             {
-                "key": "o",
                 "description": "přikázat Polsku a Litvě odstranění plotu",
                 "delay": -1,
                 "flag_set": "fence_pl",

--- a/eu2020/data/ev_members_hu.py
+++ b/eu2020/data/ev_members_hu.py
@@ -14,7 +14,6 @@ ev_member_country_hu = [
                 }
             },
             {
-                "key": "k",
                 "description": "udělit pokutu 200 000 000 EUR",
                 "delay": -1,
                 "impact": {
@@ -46,7 +45,6 @@ ev_member_country_hu = [
         },
         "options": [
             {
-                "key": "o",
                 "description": "nařídit Maďarsku odstranění plotu",
                 "delay": -1,
                 "flag_set": "fence_hu",
@@ -55,7 +53,6 @@ ev_member_country_hu = [
                 }
             },
             {
-                "key": "s",
                 "description": "odsouhlasit plot jako zlepšení ochrany vnějších hranic EU",
                 "delay": -1,
                 "flag_set": "fence_hu",

--- a/eu2020/data/ev_members_lu.py
+++ b/eu2020/data/ev_members_lu.py
@@ -16,7 +16,6 @@ ev_member_country_lu = [
                 }
             },
             {
-                "key": "k",
                 "description": "udělit Maďarsku pokutu 200 000 000 EUR",
                 "delay": -1,
                 "impact": {

--- a/eu2020/data/ev_members_pl.py
+++ b/eu2020/data/ev_members_pl.py
@@ -13,7 +13,6 @@ ev_member_country_pl = [
                 }
             },
             {
-                "key": "k",
                 "description": "udělit pokutu 200 000 000 EUR",
                 "delay": -1,
                 "impact": {
@@ -36,7 +35,6 @@ ev_member_country_pl = [
                        "v právnické komunitě v celé Evropské unii.",
         "options": [
             {
-                "key": "k",
                 "description": "udělit pokutu 200 000 000 EUR a zahájit kroky k vyloučení Polska z EU",
                 "delay": -1,
                 "impact": {

--- a/eu2020/data/ev_story_covid19.py
+++ b/eu2020/data/ev_story_covid19.py
@@ -137,7 +137,6 @@ ev_story_covid19 = [
         },
         "options": [
             {
-                "key": "v",
                 "description": "vzít na vědomí",
                 "delay": -1,
             },
@@ -152,7 +151,6 @@ ev_story_covid19 = [
         },
         "options": [
             {
-                "key": "v",
                 "description": "vzít na vědomí",
                 "delay": -1,
             },
@@ -201,7 +199,6 @@ ev_story_covid19 = [
         },
         "options": [
             {
-                "key": "v",
                 "description": "vzít na vědomí",
                 "delay": -1,
             },
@@ -215,7 +212,6 @@ ev_story_covid19 = [
         },
         "options": [
             {
-                "key": "v",
                 "description": "vzít na vědomí",
                 "delay": -1,
             },
@@ -340,7 +336,6 @@ ev_story_covid19 = [
         },
         "options": [
             {
-                "key": "z",
                 "description": "zrušit registraci pro vakcínu AstraZeneka",
                 "delay": -1,
                 "impact": {
@@ -353,7 +348,6 @@ ev_story_covid19 = [
                 }
             },
             {
-                "key": "d",
                 "description": "doporučit použití vakcíny AstraZeneca jen pro lidi 60+",
                 "delay": 12,
                 "impact": {
@@ -363,7 +357,6 @@ ev_story_covid19 = [
                 }
             },
             {
-                "key": "n",
                 "description": "nerozhodnout teď",
                 "delay": 2,
                 "impact": {

--- a/eu2020/data/ev_story_vrbetice.py
+++ b/eu2020/data/ev_story_vrbetice.py
@@ -7,7 +7,6 @@ ev_story_vrbetice = [
                        "ruští agenti. Česká vláda žádá společnou reakci na úrovni EU.",
         "options": [
             {
-                "key": "d",
                 "description": "přijmout deklaraci a odsoudit Rusko za operace na území svrchovaného státu",
                 "delay": -1,
                 "flag_set": "vrbetice",
@@ -16,7 +15,6 @@ ev_story_vrbetice = [
                 }
             },
             {
-                "key": "s",
                 "description": "odsoudit Rusko a přijmout sankce",
                 "delay": -1,
                 "flag_set": "vrbetice",


### PR DESCRIPTION
Tak jsem tu funkci `auto_set_option_keys` ještě malinko upravil a `"key":` atribut jsem vyhodil i ze zbytku událostí. Neříkám že je to teď dokonalé, ale události jsou už bez option key.