### PR TITLE
Schema validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
     - name: Test with pytest
       run: |

--- a/eu2020/data/ev_admin_eb.py
+++ b/eu2020/data/ev_admin_eb.py
@@ -28,9 +28,6 @@ ev_admin_eb = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },
@@ -60,16 +57,10 @@ ev_admin_eb = [
             {
                 "description": "odmítnout zavedení kvantitativního uvolňování",
                 "delay": 12,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },

--- a/eu2020/data/ev_admin_er.py
+++ b/eu2020/data/ev_admin_er.py
@@ -40,9 +40,6 @@ ev_admin_er = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },

--- a/eu2020/data/ev_admin_esd.py
+++ b/eu2020/data/ev_admin_esd.py
@@ -30,9 +30,6 @@ ev_admin_esd = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },
@@ -63,8 +60,6 @@ ev_admin_esd = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_deep_state_nez.py
+++ b/eu2020/data/ev_deep_state_nez.py
@@ -52,8 +52,6 @@ ev_deep_state_nez = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_empires_ru.py
+++ b/eu2020/data/ev_empires_ru.py
@@ -55,8 +55,6 @@ ev_empires_ru = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_members_cz.py
+++ b/eu2020/data/ev_members_cz.py
@@ -22,8 +22,6 @@ ev_member_country_cz = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_members_de.py
+++ b/eu2020/data/ev_members_de.py
@@ -30,8 +30,6 @@ ev_member_country_de = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_members_gr.py
+++ b/eu2020/data/ev_members_gr.py
@@ -96,8 +96,6 @@ ev_member_country_gr = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_members_hu.py
+++ b/eu2020/data/ev_members_hu.py
@@ -31,8 +31,6 @@ ev_member_country_hu = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },
@@ -64,8 +62,6 @@ ev_member_country_hu = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_members_pl.py
+++ b/eu2020/data/ev_members_pl.py
@@ -23,8 +23,6 @@ ev_member_country_pl = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },
@@ -53,8 +51,6 @@ ev_member_country_pl = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },

--- a/eu2020/data/ev_story_greendeal.py
+++ b/eu2020/data/ev_story_greendeal.py
@@ -71,9 +71,6 @@ ev_story_greendeal = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },
@@ -108,9 +105,6 @@ ev_story_greendeal = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                    "satisfaction": {},
-                }
             },
         ]
     },

--- a/eu2020/data/ev_story_vrbetice.py
+++ b/eu2020/data/ev_story_vrbetice.py
@@ -32,8 +32,6 @@ ev_story_vrbetice = [
             {
                 "description": "nerozhodnout teď",
                 "delay": 2,
-                "impact": {
-                }
             },
         ]
     },
@@ -55,8 +53,6 @@ ev_story_vrbetice = [
             {
                 "description": "ignorovat",
                 "delay": -1,
-                "impact": {
-                }
             },
         ]
     },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 flake8
+jsonschema


### PR DESCRIPTION
Ahoj Jardo, trochu jsem si hrál s knihovnou [jsonschema](https://python-jsonschema.readthedocs.io/en/latest/)
a validací dat.

Pokusil jsem se napsat co nejpřesnější schéma pro data událostí (viz nový test) a na základě toho jsem vyhodil některé prázdné slovníky v datech, kontrétně pod `event["options"]["impact"]["satisfaction"]` a `event["options"]["impact"]`

Obě tato pole jsem nastavil jako nepovinná, protože např. volby "vzít na vědomí" už teď žádný `impact` nemají.

Zároveň jsem u nepovinných polí nastavil minimální délku 1, takže ty výše uvedené prázdné mi test vyhodí jako ValidationError.

Koukni na to, zkus třeba něco v datech pozměnit a projet testy a dej vědět co si o tom myslíš.

Michal
